### PR TITLE
Creating .remarkrc.yaml

### DIFF
--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -1,0 +1,8 @@
+plugins:
+  preset-lint-consistent
+  preset-lint-markdown-style-guide
+  preset-lint-recommended
+  
+  # Customized Settings
+  lint-list-item-indent: space 
+  lint-maximum-line-length: 100


### PR DESCRIPTION
Tightening up the lists to conform with Github's preferred style
- Reducing gap between the list marker and it's content from 3 spaces to 1
- Limiting the line length to 100 characters to increase readability when the screen is reduced in side.